### PR TITLE
feat: Add an example for Cache and Database lookups

### DIFF
--- a/java/lib/src/main/java/momento/client/example/advanced/MomentoCacheWithDatabase.java
+++ b/java/lib/src/main/java/momento/client/example/advanced/MomentoCacheWithDatabase.java
@@ -1,6 +1,10 @@
 package momento.client.example.advanced;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import momento.sdk.Cache;
 import momento.sdk.Momento;
 import momento.sdk.messages.CacheGetResponse;
@@ -40,9 +44,8 @@ public class MomentoCacheWithDatabase {
         System.out.println(String.format("\n \nLookup Item id: %s again.", itemId));
 
         String secondLookup =
-                lookup(itemId, cache, database)
-                        .orElseThrow(
-                                () -> new AssertionError("Item should be present."));
+            lookup(itemId, cache, database)
+                .orElseThrow(() -> new AssertionError("Item should be present."));
         System.out.println(String.format("Look up for Item id: %s Item: %s", itemId, secondLookup));
       }
 


### PR DESCRIPTION
```
Initiating Lookup for item id: 1
Cache lookup up for item id: 1 resulted in : Miss
Item with id: 1 found in database
Item stored with key: 1 and value: Bananas stored in Cache
Look up for Item id: 1 Item: Bananas 
 

Lookup Item id: 1 again.
Cache lookup up for item id: 1 resulted in : Hit
Look up for Item id: 1 Item: Bananas
Done looking up item id: 1 
 

Initiating Lookup for item id: 20
Cache lookup up for item id: 20 resulted in : Miss
Item with id: 20 not found in database
Look up for Item id: 20 Item: Not Found in Cache or Database 
 

Done looking up item id: 20 
```