### PR TITLE
feat: bump typescript sdk to 0.3.0, example of storing files in cache

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -48,7 +48,7 @@ console.log("result: ", res.text())
 // sets key with ttl of 5 seconds
 await cache.set("key2", "value2", 5)
 
-// permantently deletes cache
+// permanently deletes cache
 await momento.deleteCache("myCache")
 ```
 
@@ -66,4 +66,20 @@ const res = await cache.get("non-existent key")
 if (res.result === MomentoCacheResult.Miss) {
     console.log("cache miss")
 }
+```
+
+Storing Files
+```typescript
+const buffer = fs.readFileSync("./package.json");
+const filebytes = Uint8Array.from(buffer);
+const cacheKey = "key";
+
+// store file in cache
+await cache.set(cacheKey, filebytes);
+
+// retrieve file from cache
+const getResp = await cache.get(cacheKey);
+
+// write file to disk
+fs.writeFileSync('./package2.json', Buffer.from(getResp.bytes()));
 ```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -55,8 +55,8 @@ Momento also supports storing pure bytes,
 ```typescript
 const key = new Uint8Array([109,111,109,101,110,116,111])
 const value = new Uint8Array([109,111,109,101,110,116,111,32,105,115,32,97,119,101,115,111,109,101,33,33,33])
-await cache.setBytes(key, value, 50)
-await cache.getBytes(key)
+await cache.set(key, value, 50)
+await cache.get(key)
 ```
 
 Handling cache misses

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -69,7 +69,7 @@ if (res.result === MomentoCacheResult.Miss) {
 
 Storing Files
 ```typescript
-const buffer = fs.readFileSync("./package.json");
+const buffer = fs.readFileSync("./file.txt");
 const filebytes = Uint8Array.from(buffer);
 const cacheKey = "key";
 
@@ -80,5 +80,5 @@ await cache.set(cacheKey, filebytes);
 const getResp = await cache.get(cacheKey);
 
 // write file to disk
-fs.writeFileSync('./package2.json', Buffer.from(getResp.bytes()));
+fs.writeFileSync('./file-from-cache.txt', Buffer.from(getResp.bytes()));
 ```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -7,7 +7,6 @@
 npm config set @momento:registry https://momento.jfrog.io/artifactory/api/npm/npm-public/
 cd typescript
 npm install
-npm run build
 
 # Run example code
 MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> npm run example

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -19,6 +19,7 @@ const main = async () => {
 
     await cache.set(cacheKey, cacheValue)
     const getResp = await cache.get(cacheKey)
+
     if (getResp.result === MomentoCacheResult.Hit) {
         console.log(`cache hit: ${getResp.text()}`)
     } else {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@momento/sdk": "0.2.2"
+        "@momento/sdk": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@momento/sdk": {
-      "version": "0.2.2",
-      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/sdk/-/@momento/sdk-0.2.2.tgz",
-      "integrity": "sha1-1D0bUHrWAByPZvM1Z6bo1ByLrlo=",
+      "version": "0.3.0",
+      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/sdk/-/@momento/sdk-0.3.0.tgz",
+      "integrity": "sha1-lvBW52mlvwr0Vk93Xjfm7c1sM0o=",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "1.3.7",
@@ -58,9 +58,9 @@
       "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
-      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg=="
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
     "node_modules/google-protobuf": {
       "version": "3.18.1",
@@ -96,9 +96,9 @@
       }
     },
     "@momento/sdk": {
-      "version": "0.2.2",
-      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/sdk/-/@momento/sdk-0.2.2.tgz",
-      "integrity": "sha1-1D0bUHrWAByPZvM1Z6bo1ByLrlo=",
+      "version": "0.3.0",
+      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/sdk/-/@momento/sdk-0.3.0.tgz",
+      "integrity": "sha1-lvBW52mlvwr0Vk93Xjfm7c1sM0o=",
       "requires": {
         "@grpc/grpc-js": "1.3.7",
         "@momento/wire-types-typescript": "0.1.4",
@@ -121,9 +121,9 @@
       "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw=="
     },
     "@types/node": {
-      "version": "16.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
-      "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg=="
+      "version": "16.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
+      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
     "google-protobuf": {
       "version": "3.18.1",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -14,6 +14,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@momento/sdk": "0.2.2"
+    "@momento/sdk": "0.3.0"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "build": "tsc",
-    "example": "node dist/index.js"
+    "example": "tsc && node dist/index.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- Uses new overloaded methods to support byte keys and string keys
- Adds example of storing files in cache