### PR TITLE
fix: Update the NPM Registry Link for Install

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -19,7 +19,7 @@ Example Code: [index.ts](index.ts)
 
 ### Installation
 ```bash
-npm config set @momento:registry https://momento.jfrog.io/artifactory/npm-public/
+npm config set @momento:registry https://momento.jfrog.io/artifactory/api/npm/npm-public/
 npm install @momento/sdk
 ```
 


### PR DESCRIPTION
An incorrect registry link was causing the SDK installation failure. As reported in #35