### PR TITLE
fix: Handle Nones gracefully

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -42,5 +42,5 @@ if __name__ == "__main__":
             print('Getting Key: ' + _KEY)
             get_resp = cache_client.get('MyKey')
             print('Look up resulted in a : ' + str(get_resp.result()))
-            print('Looked up Value: ' + get_resp.str_utf8())
+            print('Looked up Value: ' + str(get_resp.str_utf8()))
     _print_end_banner()

--- a/python/example.py
+++ b/python/example.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
             print('Setting Key: ' + _KEY + ' Value: ' + _VALUE)
             cache_client.set(_KEY, _VALUE)
             print('Getting Key: ' + _KEY)
-            get_resp = cache_client.get('MyKey')
+            get_resp = cache_client.get(_KEY)
             print('Look up resulted in a : ' + str(get_resp.result()))
             print('Looked up Value: ' + str(get_resp.str_utf8()))
     _print_end_banner()


### PR DESCRIPTION
If the Cache lookup results in Miss, then the program fails with
`TypeError: can only concatenate str (not "NoneType") to str`

Adding a cast to gracefully handle Cache Misses