### PR TITLE
feat: Upgrade Java SDK Version

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -25,6 +25,6 @@ repositories {
 }
 
 dependencies {
-    implementation("momento.sandbox:momento-sdk:0.17.0")
+    implementation("momento.sandbox:momento-sdk:0.18.0")
 }
 ```

--- a/java/lib/build.gradle.kts
+++ b/java/lib/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("momento.sandbox:momento-sdk:0.17.0")
+    implementation("momento.sandbox:momento-sdk:0.18.0")
 
     // Use JUnit Jupiter for testing.
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.2")

--- a/java/lib/src/main/java/momento/client/example/MomentoCacheApplication.java
+++ b/java/lib/src/main/java/momento/client/example/MomentoCacheApplication.java
@@ -1,7 +1,7 @@
 package momento.client.example;
 
 import momento.sdk.SimpleCacheClient;
-import momento.sdk.exceptions.CacheAlreadyExistsException;
+import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.messages.CacheGetResponse;
 
 public class MomentoCacheApplication {
@@ -25,7 +25,7 @@ public class MomentoCacheApplication {
       System.out.println(String.format("Getting value for key=`%s`", KEY));
 
       CacheGetResponse getResponse = simpleCacheClient.get(CACHE_NAME, KEY);
-      System.out.println(String.format("Lookup resulted in: `%s`", getResponse.result()));
+      System.out.println(String.format("Lookup resulted in: `%s`", getResponse.status()));
       System.out.println(
           String.format("Looked up value=`%s`", getResponse.string().orElse("NOT FOUND")));
     }
@@ -35,7 +35,7 @@ public class MomentoCacheApplication {
   private static void createCache(SimpleCacheClient simpleCacheClient, String cacheName) {
     try {
       simpleCacheClient.createCache(cacheName);
-    } catch (CacheAlreadyExistsException e) {
+    } catch (AlreadyExistsException e) {
       System.out.println(String.format("Cache with name `%s` already exists.", cacheName));
     }
   }

--- a/java/lib/src/main/java/momento/client/example/advanced/MomentoCacheWithDatabase.java
+++ b/java/lib/src/main/java/momento/client/example/advanced/MomentoCacheWithDatabase.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import momento.sdk.SimpleCacheClient;
-import momento.sdk.exceptions.CacheAlreadyExistsException;
+import momento.sdk.exceptions.AlreadyExistsException;
 import momento.sdk.messages.CacheGetResponse;
 
 /**
@@ -80,13 +80,13 @@ public class MomentoCacheWithDatabase {
 
   private static void writeCacheLog(CacheGetResponse response, String key) {
     System.out.println(
-        String.format("Cache lookup up for item id: %s resulted in : %s", key, response.result()));
+        String.format("Cache lookup up for item id: %s resulted in : %s", key, response.status()));
   }
 
   private static void createCache(SimpleCacheClient simpleCacheClient, String cacheName) {
     try {
       simpleCacheClient.createCache(cacheName);
-    } catch (CacheAlreadyExistsException e) {
+    } catch (AlreadyExistsException e) {
       System.out.println(String.format("Cache with name `%s` already exists.", cacheName));
     }
   }


### PR DESCRIPTION
Includes:
Handle all status codes
Remove Optional from SetResponse values
Service now returns UNAUTHENTICATED instead of PERMISSION_DENIED
result() -> status()
Flatten exception hierarchy
Remove listCaches builder pattern

```
 MOMENTO_AUTH_TOKEN=<TOKEN> ./gradlew run
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Task :lib:run
******************************************************************
*                      Momento Example Start                     *
******************************************************************
Cache with name `cache` already exists.
Setting key=`key` , value=`value`
Getting value for key=`key`
Lookup resulted in: `HIT`
Looked up value=`value`
******************************************************************
*                       Momento Example End                      *
******************************************************************

```