### PR TITLE
fix: Update dotnet example to not fail on `AlreadyExistsException` and upgrade TargetFramework to `net6.0`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
 
       - name: Configure Artifactory
         run: |

--- a/dotnet/MomentoExamples/MomentoApplication/MomentoApplication.csproj
+++ b/dotnet/MomentoExamples/MomentoApplication/MomentoApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
 

--- a/dotnet/MomentoExamples/MomentoApplication/Program.cs
+++ b/dotnet/MomentoExamples/MomentoApplication/Program.cs
@@ -19,7 +19,7 @@ namespace MomentoApplication
             {
                 client.CreateCache(CACHE_NAME);
             }
-            catch (AlreadyExistsException e)
+            catch (AlreadyExistsException)
             {
                 Console.WriteLine($"Cache with name {CACHE_NAME} already exists.");
             }

--- a/dotnet/MomentoExamples/MomentoApplication/Program.cs
+++ b/dotnet/MomentoExamples/MomentoApplication/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using MomentoSdk;
+using MomentoSdk.Exceptions;
 using MomentoSdk.Responses;
 
 namespace MomentoApplication
@@ -15,7 +15,14 @@ namespace MomentoApplication
         static void Main(string[] args)
         {
             using SimpleCacheClient client = new SimpleCacheClient(MOMENTO_AUTH_TOKEN, DEFAULT_TTL_SECONDS);
-            client.CreateCache(CACHE_NAME);
+            try
+            {
+                client.CreateCache(CACHE_NAME);
+            }
+            catch (AlreadyExistsException e)
+            {
+                Console.WriteLine($"Cache with name {CACHE_NAME} already exists.");
+            }
             Console.WriteLine($"Setting Key: {KEY} with Value: {VALUE}");
             client.Set(CACHE_NAME, KEY, VALUE);
             Console.WriteLine($"Get Value for  Key: {KEY}");

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,8 +1,10 @@
 ## Prerequisites
+
 - [.NET SDK](https://dotnet.microsoft.com/download)
 - A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
 
 ## Running the Example
+
 ```bash
 cd MomentoExamples
 dotnet nuget add source https://momento.jfrog.io/artifactory/api/nuget/nuget-public --name Momento-Artifactory
@@ -13,11 +15,13 @@ MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoApplication
 Example Code: [MomentoApplication](MomentoExamples/MomentoApplication/Program.cs)
 
 ## Using the .NET SDK in your project
-SDK is built for target framework [.NET Standard 2.1 ](https://github.com/dotnet/standard/blob/master/docs/versions/netstandard2.1.md)
+
+SDK is built for target framework [.NET Standard 2.1](https://github.com/dotnet/standard/blob/v2.1.0/docs/versions/netstandard2.1.md)
 
 The Momento SDK is available at https://momento.jfrog.io/ui/repos/tree/General/nuget-public
 
 ### CLI command to add to your project
+
 ```
 dotnet nuget add source https://momento.jfrog.io/artifactory/api/nuget/nuget-public --name Momento-Artifactory
 dotnet add package MomentoSdk


### PR DESCRIPTION
- Updated the dotnet example so that it won't fail when cache already exists
- Upgraded TargetFramework to `net6.0` to align with their recommended .NET version

Closes #74 
Closes #75