### PR TITLE
chore: add net45 MomentoSigner example

### DIFF
--- a/dotnet/MomentoExamples/MomentoApplicationPresignedUrl/MomentoApplicationPresignedUrl.csproj
+++ b/dotnet/MomentoExamples/MomentoApplicationPresignedUrl/MomentoApplicationPresignedUrl.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MomentoSdk" Version="0.9.1" />
+    <PackageReference Include="MomentoSdk" Version="0.10.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/MomentoExamples/MomentoApplicationPresignedUrlNet45/Program.cs
+++ b/dotnet/MomentoExamples/MomentoApplicationPresignedUrlNet45/Program.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Net.Http;
 using System.Threading.Tasks;
-using MomentoSdk;
+using MomentoSdkDotnet45;
 
 namespace MomentoApplicationPresignedUrl
 {
@@ -51,7 +51,7 @@ namespace MomentoApplicationPresignedUrl
             }
 
             // prepare requests
-            uint expiryEpochSeconds = (uint) DateTimeOffset.UtcNow.AddMinutes(URL_TTL_MINUTES).ToUnixTimeSeconds();
+            uint expiryEpochSeconds = (uint) DateTimeOffset.UtcNow.AddMinutes(URL_TTL_MINUTES).Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
             var setReq = new SigningRequest(cacheName, OBJECT_KEY, CacheOperation.SET, expiryEpochSeconds) { TtlSeconds = OBJECT_TTL_SECONDS };
             var getReq = new SigningRequest(cacheName, OBJECT_KEY, CacheOperation.GET, expiryEpochSeconds);
             Console.WriteLine($"Request claims: exp = {expiryEpochSeconds}, cache = {cacheName}, key = {OBJECT_KEY}, ttl (for set) = {OBJECT_TTL_SECONDS}");

--- a/dotnet/MomentoExamples/MomentoApplicationPresignedUrlNet45/README.md
+++ b/dotnet/MomentoExamples/MomentoApplicationPresignedUrlNet45/README.md
@@ -1,0 +1,15 @@
+## MomentoSdkDotnet45
+
+SDK is built for target framework .NET Framework 4.5 or above. Only MomentoSigner is supported.
+
+## To add to your project
+
+In Visual Studio project, open the NuGet Package Manager. 
+
+Add package source https://momento.jfrog.io/artifactory/api/nuget/nuget-public.
+
+Install the package MomentoSdkDotnet45.
+
+## Example Code for Presigned URL Creation
+
+[Program.cs](Program.cs)


### PR DESCRIPTION
See also https://github.com/momentohq/client-sdk-csharp/pull/51

This PR:
1. updated MomentoSdk version (that uses rest endpoint)
2. added readme/example for MomentoSigner SDK on .net45