### PR TITLE
Fix small typo in README install instructions

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -24,7 +24,7 @@ Example Code: [index.ts](index.ts)
 ### Installation
 
 ```bash
-npm install npm i @gomomento/sdk
+npm install @gomomento/sdk
 ```
 
 ### Usage


### PR DESCRIPTION
Used `npm install` instead of `npm i` to match README.ja.md