### PR TITLE
feat: Add examples for presigned urls for javascript

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -19,6 +19,23 @@ MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> npm run example
 
 Example Code: [index.ts](index.ts)
 
+## Running the Presigned URL Example
+
+This example demonstrates how to use the `MomentoSigner` class, which enables creation of user-signed access tokens and presigned urls which can be used for doing cache get/set actions via HTTP.
+
+- Node version 16 or higher is required
+- A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
+
+```bash
+cd javascript
+npm install
+
+# Run example code
+MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> npm run presigned-url-example
+```
+
+Example Code: [presigned-url-example.ts](presigned-url-example.ts)
+
 ## Using the SDK in your projects
 
 ### Installation

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -12,10 +12,12 @@
         "@gomomento/generated-types": "0.20.0",
         "@gomomento/sdk": "0.14.3",
         "@grpc/grpc-js": "1.5.10",
-        "hdr-histogram-js": "3.0.0"
+        "hdr-histogram-js": "3.0.0",
+        "node-fetch": "^2.6.7"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
+        "@types/node-fetch": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "5.30.5",
         "eslint": "8.19.0",
         "eslint-config-prettier": "8.5.0",
@@ -251,6 +253,16 @@
       "version": "16.11.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
       "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
@@ -681,6 +693,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -804,6 +822,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -869,6 +899,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -1554,6 +1593,20 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2224,6 +2277,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2252,6 +2326,25 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
@@ -3000,6 +3093,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3104,6 +3202,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3408,6 +3520,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
       "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.5.tgz",
@@ -3665,6 +3787,12 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -3753,6 +3881,15 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3799,6 +3936,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -4333,6 +4476,17 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4821,6 +4975,21 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4846,6 +5015,14 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -5373,6 +5550,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5452,6 +5634,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@gomomento/generated-types": "0.20.0",
-        "@gomomento/sdk": "0.14.3",
+        "@gomomento/sdk": "0.15.0",
         "@grpc/grpc-js": "1.5.10",
         "hdr-histogram-js": "3.0.0",
         "node-fetch": "^2.6.7"
@@ -64,12 +64,13 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-0.14.3.tgz",
-      "integrity": "sha512-ktGWhyJ6v7q/exNxoM2y6W3Bx64dPV2xMU4iIWCMHRmJxjzcghcubCmErJB87+ooVh+2Vm8W65qYRIVyKSRB5g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-0.15.0.tgz",
+      "integrity": "sha512-0ZBl/tc20Qx8TK6eUrv3Eelss9wBHFl9jV3AoTX8v08UN0Sbz02DjK8G1wzZVzHWJdM+KC2+vU+ZwojEeDn79A==",
       "dependencies": {
         "@gomomento/generated-types": "0.13.0",
         "@grpc/grpc-js": "1.5.10",
+        "jose": "4.8.3",
         "jwt-decode": "3.1.2",
         "pino": "8.1.0",
         "pino-pretty": "8.1.0"
@@ -250,13 +251,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-      "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
+      "version": "16.11.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
+      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dev": true,
       "dependencies": {
@@ -298,15 +299,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.7.tgz",
-      "integrity": "sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -326,14 +327,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz",
-      "integrity": "sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -344,13 +345,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-      "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -418,9 +419,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.7.tgz",
-      "integrity": "sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -432,14 +433,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz",
-      "integrity": "sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -460,13 +461,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-      "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -583,9 +584,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -695,8 +696,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/atomic-sleep": {
@@ -824,7 +825,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "dependencies": {
@@ -903,8 +904,8 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -1378,17 +1379,20 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
@@ -1595,7 +1599,7 @@
     },
     "node_modules/form-data": {
       "version": "3.0.1",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/form-data/-/form-data-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "dependencies": {
@@ -1739,9 +1743,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-      "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1985,9 +1989,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -2152,6 +2156,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jose": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
+      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -2279,7 +2291,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "engines": {
@@ -2288,7 +2300,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "dependencies": {
@@ -2329,7 +2341,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/node-fetch/-/node-fetch-2.6.7.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2365,14 +2377,14 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -2884,9 +2896,9 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
-      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "node_modules/semver": {
       "version": "7.3.7",
@@ -2948,9 +2960,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
-      "integrity": "sha512-p5DiZOZHbJ2ZO5MADczp5qrfOd3W5Vr2vHxfCpe7G4AzPwVOweIjbfgku8wSQUuk+Y5Yuo8W7JqRe6XKmKistg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -3095,8 +3107,8 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -3205,13 +3217,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3352,12 +3364,13 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-0.14.3.tgz",
-      "integrity": "sha512-ktGWhyJ6v7q/exNxoM2y6W3Bx64dPV2xMU4iIWCMHRmJxjzcghcubCmErJB87+ooVh+2Vm8W65qYRIVyKSRB5g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-0.15.0.tgz",
+      "integrity": "sha512-0ZBl/tc20Qx8TK6eUrv3Eelss9wBHFl9jV3AoTX8v08UN0Sbz02DjK8G1wzZVzHWJdM+KC2+vU+ZwojEeDn79A==",
       "requires": {
         "@gomomento/generated-types": "0.13.0",
         "@grpc/grpc-js": "1.5.10",
+        "jose": "4.8.3",
         "jwt-decode": "3.1.2",
         "pino": "8.1.0",
         "pino-pretty": "8.1.0"
@@ -3516,13 +3529,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "16.11.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-      "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ=="
+      "version": "16.11.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
+      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dev": true,
       "requires": {
@@ -3548,37 +3561,37 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.7.tgz",
-      "integrity": "sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.30.7",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz",
-          "integrity": "sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==",
+          "version": "5.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+          "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
           "dev": true,
           "peer": true,
           "requires": {
-            "@typescript-eslint/types": "5.30.7",
-            "@typescript-eslint/visitor-keys": "5.30.7"
+            "@typescript-eslint/types": "5.33.0",
+            "@typescript-eslint/visitor-keys": "5.33.0"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.30.7",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-          "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+          "version": "5.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+          "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
           "dev": true,
           "peer": true,
           "requires": {
-            "@typescript-eslint/types": "5.30.7",
+            "@typescript-eslint/types": "5.33.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         }
@@ -3614,21 +3627,21 @@
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.7.tgz",
-      "integrity": "sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true,
       "peer": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz",
-      "integrity": "sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3637,13 +3650,13 @@
       },
       "dependencies": {
         "@typescript-eslint/visitor-keys": {
-          "version": "5.30.7",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-          "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+          "version": "5.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+          "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
           "dev": true,
           "peer": true,
           "requires": {
-            "@typescript-eslint/types": "5.30.7",
+            "@typescript-eslint/types": "5.33.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         }
@@ -3713,9 +3726,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -3789,8 +3802,8 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "atomic-sleep": {
@@ -3883,7 +3896,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
@@ -3939,8 +3952,8 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "dir-glob": {
@@ -4300,12 +4313,12 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
@@ -4478,7 +4491,7 @@
     },
     "form-data": {
       "version": "3.0.1",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/form-data/-/form-data-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "requires": {
@@ -4588,9 +4601,9 @@
       }
     },
     "globals": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-      "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4764,9 +4777,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4874,6 +4887,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "jose": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
+      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g=="
+    },
     "joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -4977,13 +4995,13 @@
     },
     "mime-db": {
       "version": "1.52.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
@@ -5018,7 +5036,7 @@
     },
     "node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/node-fetch/-/node-fetch-2.6.7.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -5037,14 +5055,14 @@
       "dev": true
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -5395,9 +5413,9 @@
       "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "secure-json-parse": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
-      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "semver": {
       "version": "7.3.7",
@@ -5441,9 +5459,9 @@
       "dev": true
     },
     "sonic-boom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.0.0.tgz",
-      "integrity": "sha512-p5DiZOZHbJ2ZO5MADczp5qrfOd3W5Vr2vHxfCpe7G4AzPwVOweIjbfgku8wSQUuk+Y5Yuo8W7JqRe6XKmKistg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
       "requires": {
         "atomic-sleep": "^1.0.0"
       }
@@ -5552,8 +5570,8 @@
     },
     "tr46": {
       "version": "0.0.3",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -5637,13 +5655,13 @@
     },
     "webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://momento-prod-401011790710.d.codeartifact.us-west-2.amazonaws.com:443/npm/npm-upstream/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@gomomento/generated-types": "0.20.0",
-    "@gomomento/sdk": "0.14.3",
+    "@gomomento/sdk": "0.15.0",
     "@grpc/grpc-js": "1.5.10",
     "hdr-histogram-js": "3.0.0",
     "node-fetch": "2.6.7"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -32,6 +32,6 @@
     "@gomomento/sdk": "0.14.3",
     "@grpc/grpc-js": "1.5.10",
     "hdr-histogram-js": "3.0.0",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "2.6.7"
   }
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^16.11.4",
-    "@types/node-fetch": "^2.6.2",
+    "@types/node-fetch": "2.6.2",
     "@typescript-eslint/eslint-plugin": "5.30.5",
     "eslint": "8.19.0",
     "eslint-config-prettier": "8.5.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,6 +7,7 @@
     "prebuild": "eslint . --ext .ts",
     "build": "tsc",
     "example": "tsc && node dist/index.js",
+    "presigned-url-example": "tsc && node dist/presigned-url-example.js",
     "load-gen": "tsc && node dist/load-gen.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
@@ -16,6 +17,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^16.11.4",
+    "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "5.30.5",
     "eslint": "8.19.0",
     "eslint-config-prettier": "8.5.0",
@@ -29,6 +31,7 @@
     "@gomomento/generated-types": "0.20.0",
     "@gomomento/sdk": "0.14.3",
     "@grpc/grpc-js": "1.5.10",
-    "hdr-histogram-js": "3.0.0"
+    "hdr-histogram-js": "3.0.0",
+    "node-fetch": "^2.6.7"
   }
 }

--- a/javascript/presigned-url-example.ts
+++ b/javascript/presigned-url-example.ts
@@ -18,7 +18,7 @@ const authToken = requireEnvVar('MOMENTO_AUTH_TOKEN');
 const defaultTtl = 60;
 const momento = new SimpleCacheClient(authToken, defaultTtl, {
   loggerOptions: {
-    level: LogLevel.DEBUG,
+    level: LogLevel.INFO,
     format: LogFormat.CONSOLE,
   },
 });
@@ -84,7 +84,7 @@ async function runPresignedUrlExample(signer: MomentoSigner, endpoint: string) {
     expiryEpochSeconds: expiryEpochSeconds,
   });
   console.log(
-    `Created signed urls with claims: exp = ${expiryEpochSeconds}, cache = ${cacheName}, key = ${cacheKey}, ttl (for set) = ${objectTtlSeconds}`
+    `Created signed urls with claims: exp = ${expiryEpochSeconds}, cache = ${cacheName}, key = ${cacheKey}, ttl seconds (for set) = ${objectTtlSeconds}`
   );
 
   console.log(

--- a/javascript/presigned-url-example.ts
+++ b/javascript/presigned-url-example.ts
@@ -1,34 +1,83 @@
-import {MomentoSigner, CacheOperation} from '@gomomento/sdk';
+import {
+  MomentoSigner,
+  CacheOperation,
+  SimpleCacheClient,
+  LogLevel,
+  LogFormat,
+  AlreadyExistsError,
+} from '@gomomento/sdk';
 import fetch, {Response} from 'node-fetch';
 
-const signingKey = requireEnvVar('MOMENTO_SIGNING_KEY');
-const signingEndpoint = requireEnvVar('MOMENTO_ENDPOINT');
-const cacheName = getCacheName();
+const cacheName = 'MyCache';
 const cacheKey = 'MyCacheKey';
 const cacheValue = 'MyCacheValue';
 const expiryEpochSeconds = Math.floor(Date.now() / 1000) + 10 * 60; // 10 minutes from now
 const objectTtlSeconds = 180;
 
+const authToken = requireEnvVar('MOMENTO_AUTH_TOKEN');
+const defaultTtl = 60;
+const momento = new SimpleCacheClient(authToken, defaultTtl, {
+  loggerOptions: {
+    level: LogLevel.DEBUG,
+    format: LogFormat.CONSOLE,
+  },
+});
+
 const main = async () => {
+  console.log(`Creating cache '${cacheName}'`);
+  try {
+    await momento.createCache(cacheName);
+  } catch (e) {
+    if (e instanceof AlreadyExistsError) {
+      console.log(`Cache '${cacheName}' already exists`);
+    } else {
+      throw e;
+    }
+  }
+
+  console.log(`Checking for signing key in $MOMENTO_SIGNING_KEY`);
+  let signingKey = process.env.MOMENTO_SIGNING_KEY;
+  if (!signingKey) {
+    // There is a limit of 5 signing keys per user, so it's best practice to
+    // create a signing key and store it somewhere secure. For convenience,
+    // this example creates a new signing key if one is not set in the
+    // environment variable `MOMENTO_SIGNING_KEY`. Signing keys can also be
+    // created and revoked via the Momento CLI.
+    console.log(
+      'Did not find signing key in environment, creating new signing key'
+    );
+    const signingKeyResponse = await momento.createSigningKey(60 * 24); // valid for 24 hours
+    signingKey = signingKeyResponse.getKey();
+    process.env.MOMENTO_ENDPOINT = signingKeyResponse.getEndpoint();
+  }
+  const endpoint = requireEnvVar('MOMENTO_ENDPOINT');
+
   const signer = await MomentoSigner.init(signingKey);
 
   console.log('\n*** Running presigned url example ***');
-  await runPresignedUrlExample(signer);
+  await runPresignedUrlExample(signer, endpoint);
 
   console.log('\n*** Running signed token example ***');
-  await runSignedTokenExample(signer);
+  await runSignedTokenExample(signer, endpoint);
 };
 
-async function runPresignedUrlExample(signer: MomentoSigner) {
-  // create presigned URL
-  const setUrl = await signer.createPresignedUrl(signingEndpoint, {
+// Create signed urls for setting and getting values via http for specified cache and
+// key
+async function runPresignedUrlExample(signer: MomentoSigner, endpoint: string) {
+  console.log(
+    `Creating signed url for ${CacheOperation.Set} for cache '${cacheName}' and key '${cacheKey}'`
+  );
+  const setUrl = await signer.createPresignedUrl(endpoint, {
     cacheName: cacheName,
     cacheKey: cacheKey,
     cacheOperation: CacheOperation.Set,
     ttlSeconds: objectTtlSeconds,
     expiryEpochSeconds: expiryEpochSeconds,
   });
-  const getUrl = await signer.createPresignedUrl(signingEndpoint, {
+  console.log(
+    `Creating signed url for ${CacheOperation.Get} for cache '${cacheName}' and key '${cacheKey}'`
+  );
+  const getUrl = await signer.createPresignedUrl(endpoint, {
     cacheName: cacheName,
     cacheKey: cacheKey,
     cacheOperation: CacheOperation.Get,
@@ -38,20 +87,29 @@ async function runPresignedUrlExample(signer: MomentoSigner) {
     `Created signed urls with claims: exp = ${expiryEpochSeconds}, cache = ${cacheName}, key = ${cacheKey}, ttl (for set) = ${objectTtlSeconds}`
   );
 
-  console.log(`Posting value with signed URL: '${cacheValue}'`);
+  console.log(
+    `Setting value for cache '${cacheName}' and key '${cacheKey}' via HTTP with signed URL: '${cacheValue}'`
+  );
   const setResponse = await fetch(setUrl, {method: 'POST', body: cacheValue});
   await ensureSuccessfulResponse(setResponse);
+  console.log(
+    `Getting value for cache '${cacheName}' and key '${cacheKey}' via HTTP with signed URL`
+  );
   const getResponse = await fetch(getUrl);
   await ensureSuccessfulResponse(getResponse);
 
   const data = await getResponse.text();
   console.log(`Retrieved value with signed URL: ${JSON.stringify(data)}`);
-  console.log('Presigned url example finished successfully!\n');
+  console.log('Presigned url example finished successfully!');
 }
 
-async function runSignedTokenExample(signer: MomentoSigner) {
-  // create signed token for this cache
-  const accessToken = await signer.signAccessToken({
+// Create signed token for specified cache. This token is then used for
+// setting and getting values via http. Signed tokens are restricted to a
+// specific cache, but unlike presigned urls they can be created without
+// restrictions on the operation and key they can be used for.
+async function runSignedTokenExample(signer: MomentoSigner, endpoint: string) {
+  console.log(`Creating new signed access token for cache '${cacheName}'`);
+  const signedToken = await signer.signAccessToken({
     cacheName: cacheName,
     expiryEpochSeconds: expiryEpochSeconds,
   });
@@ -61,18 +119,14 @@ async function runSignedTokenExample(signer: MomentoSigner) {
 
   // build urls
   const cacheKey = 'someKey';
-  const setUrl = buildSetUrl(
-    signingEndpoint,
-    cacheName,
-    cacheKey,
-    accessToken,
-    objectTtlSeconds
-  );
-  const getUrl = buildGetUrl(signingEndpoint, cacheName, cacheKey, accessToken);
+  const setUrl = `https://rest.${endpoint}/cache/set/${cacheName}/${cacheKey}?token=${signedToken}&ttl_milliseconds=${
+    objectTtlSeconds * 1000
+  }`;
+  const getUrl = `https://rest.${endpoint}/cache/get/${cacheName}/${cacheKey}?token=${signedToken}`;
 
   const cacheValue = 'somedata';
   console.log(
-    `Posting value via URL with signed token for key '${cacheKey}': '${cacheValue}'`
+    `Setting value for cache '${cacheName}' and key '${cacheKey}' via HTTP with signed token: '${cacheValue}'`
   );
   const setResponse = await fetch(setUrl, {method: 'POST', body: cacheValue});
   await ensureSuccessfulResponse(setResponse);
@@ -92,39 +146,6 @@ function requireEnvVar(envVarName: string): string {
     throw new Error(`Missing required environment variable ${envVarName}`);
   }
   return result;
-}
-
-function getCacheName(): string {
-  if (process.env.CACHE_NAME) {
-    return process.env.CACHE_NAME;
-  } else {
-    const defaultCacheName = 'default-cache';
-    console.log(
-      `Environment variable CACHE_NAME not set. Using cache name '${defaultCacheName}'.`
-    );
-    return defaultCacheName;
-  }
-}
-
-function buildSetUrl(
-  endpoint: string,
-  cacheName: string,
-  cacheKey: string,
-  token: string,
-  ttlSeconds: number
-): string {
-  return `https://rest.${endpoint}/cache/set/${cacheName}/${cacheKey}?token=${token}&ttl_milliseconds=${
-    ttlSeconds * 1000
-  }`;
-}
-
-function buildGetUrl(
-  endpoint: string,
-  cacheName: string,
-  cacheKey: string,
-  token: string
-): string {
-  return `https://rest.${endpoint}/cache/get/${cacheName}/${cacheKey}?token=${token}`;
 }
 
 async function ensureSuccessfulResponse(response: Response) {

--- a/javascript/presigned-url-example.ts
+++ b/javascript/presigned-url-example.ts
@@ -1,0 +1,140 @@
+import {MomentoSigner, CacheOperation} from '@gomomento/sdk';
+import fetch, {Response} from 'node-fetch';
+
+const signingKey = process.env.MOMENTO_SIGNING_KEY;
+if (!signingKey) {
+  throw new Error('Missing required environment variable MOMENTO_SIGNING_KEY');
+}
+const signingEndpoint = process.env.MOMENTO_ENDPOINT || '';
+if (signingEndpoint === '') {
+  throw new Error('Missing required environment variable MOMENTO_ENDPOINT');
+}
+
+let cacheName: string;
+if (process.env.CACHE_NAME) {
+  cacheName = process.env.CACHE_NAME;
+} else {
+  cacheName = 'default-cache';
+  console.log(
+    `Environment variable CACHE_NAME not set. Using cache name '${cacheName}'.`
+  );
+}
+const cacheKey = 'MyCacheKey';
+const cacheValue = 'MyCacheValue';
+const expiryEpochSeconds = Math.floor(Date.now() / 1000) + 10 * 60; // 10 minutes from now
+const objectTtlSeconds = 180;
+
+const main = async () => {
+  const signer = await MomentoSigner.init(signingKey);
+
+  console.log('\n*** Running presigned url example ***');
+  await runPresignedUrlExample(signer);
+
+  console.log('\n*** Running signed token example ***');
+  await runSignedTokenExample(signer);
+};
+
+async function runPresignedUrlExample(signer: MomentoSigner) {
+  // create presigned URL
+  const setUrl = await signer.createPresignedUrl(signingEndpoint, {
+    cacheName: cacheName,
+    cacheKey: cacheKey,
+    cacheOperation: CacheOperation.Set,
+    ttlSeconds: objectTtlSeconds,
+    expiryEpochSeconds: expiryEpochSeconds,
+  });
+  const getUrl = await signer.createPresignedUrl(signingEndpoint, {
+    cacheName: cacheName,
+    cacheKey: cacheKey,
+    cacheOperation: CacheOperation.Get,
+    expiryEpochSeconds: expiryEpochSeconds,
+  });
+  console.log(
+    `Created signed urls with claims: exp = ${expiryEpochSeconds}, cache = ${cacheName}, key = ${cacheKey}, ttl (for set) = ${objectTtlSeconds}`
+  );
+
+  console.log(`Posting value with signed URL: '${cacheValue}'`);
+  const setResponse = await fetch(setUrl, {method: 'POST', body: cacheValue});
+  await ensureSuccessfulResponse(setResponse);
+  const getResponse = await fetch(getUrl);
+  await ensureSuccessfulResponse(getResponse);
+
+  const data = await getResponse.text();
+  console.log(`Retrieved value with signed URL: ${JSON.stringify(data)}`);
+  console.log('Presigned url example finished successfully!\n');
+}
+
+async function runSignedTokenExample(signer: MomentoSigner) {
+  // create signed token for this cache
+  const accessToken = await signer.signAccessToken({
+    cacheName: cacheName,
+    expiryEpochSeconds: expiryEpochSeconds,
+  });
+  console.log(
+    `Created signed access token for cache '${cacheName}' with expiry ${expiryEpochSeconds}`
+  );
+
+  // build urls
+  const cacheKey = 'someKey';
+  const setUrl = buildSetUrl(
+    signingEndpoint,
+    cacheName,
+    cacheKey,
+    accessToken,
+    objectTtlSeconds
+  );
+  const getUrl = buildGetUrl(signingEndpoint, cacheName, cacheKey, accessToken);
+
+  const cacheValue = 'somedata';
+  console.log(
+    `Posting value via URL with signed token for key '${cacheKey}': '${cacheValue}'`
+  );
+  const setResponse = await fetch(setUrl, {method: 'POST', body: cacheValue});
+  await ensureSuccessfulResponse(setResponse);
+  const getResponse = await fetch(getUrl);
+  await ensureSuccessfulResponse(getResponse);
+
+  const data = await getResponse.text();
+  console.log(
+    `Retrieved value via URL with signed token: ${JSON.stringify(data)}`
+  );
+  console.log('Signed token example finished successfully!\n');
+}
+
+function buildSetUrl(
+  endpoint: string,
+  cacheName: string,
+  cacheKey: string,
+  token: string,
+  ttlSeconds: number
+) {
+  return `https://rest.${endpoint}/cache/set/${cacheName}/${cacheKey}?token=${token}&ttl_milliseconds=${
+    ttlSeconds * 1000
+  }`;
+}
+
+function buildGetUrl(
+  endpoint: string,
+  cacheName: string,
+  cacheKey: string,
+  token: string
+) {
+  return `https://rest.${endpoint}/cache/get/${cacheName}/${cacheKey}?token=${token}`;
+}
+
+async function ensureSuccessfulResponse(response: Response) {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      `Request failed for ${response.url}:\n${response.status} ${response.statusText} ${message}`
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log('success!!');
+  })
+  .catch(e => {
+    console.error('failure :(\n', e);
+  });

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "lib": [
       "es2021",
-      "dom"
     ],
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
Add a new typescript file `presigned-url-examples.ts` that shows how to use the new SDK features for creating presigned urls and signed access tokens.

Compared to the [dotnet](https://github.com/momentohq/client-sdk-examples/blob/f6e3bfe56f329ffc9ee02f8845c720a1342bfe17/dotnet/MomentoExamples/MomentoApplicationPresignedUrl/Program.cs) example, this is a little different - it has not only an example of using the `presignedUrl` function, but also an example of using `signAccessToken` with relaxed JWT claims and then using it to make http cache requests.

This depends on https://github.com/momentohq/client-sdk-javascript/pull/98 being merged and released.
