### PR TITLE
feat: adds dependabot and CI with failure notification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/dotnet/MomentoExamples/MomentoApplication" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "Momento.Sdk"
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/python" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "momento"
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/golang" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/momentohq/client-sdk-go"
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/java" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "momento-sdk"
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/javascript" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@gomomento/sdk"
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/rust" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "momento"

--- a/.github/error-email-action/action.yml
+++ b/.github/error-email-action/action.yml
@@ -1,0 +1,34 @@
+name: 'Sdk Sample Error Email'
+inputs:
+  username:
+    required: true
+  password:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: dawidd6/action-send-mail@v3
+      with:
+        # Required mail server address:
+        server_address: smtp.gmail.com
+        # Required mail server port:
+        server_port: 465
+        # Optional (recommended): mail server username:
+        username: ${{inputs.username}}
+        # Optional (recommended) mail server password:
+        password: ${{inputs.password}}
+        # Required mail subject:
+        subject: SDK Examples Build failed - ${{ github.job }} 
+        # Required recipients' addresses:
+        to: pete@momentohq.com
+        # Required sender full name (address can be skipped):
+        from: Dev Eco
+        # Optional whether this connection use TLS (default is true if server_port is 465)
+        secure: true
+        # Optional plain body:
+        body: |
+          "${{github.job}}" build job of "${{github.repository}}", branch "${{ github.head_ref || github.ref_name }}" failed!
+          See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.
+
+        # Optional unsigned/invalid certificates allowance:
+        ignore_cert: true

--- a/.github/error-email-action/action.yml
+++ b/.github/error-email-action/action.yml
@@ -20,7 +20,7 @@ runs:
         # Required mail subject:
         subject: SDK Examples Build failed - ${{ github.job }} 
         # Required recipients' addresses:
-        to: pete@momentohq.com
+        to: eng-deveco@momentohq.com
         # Required sender full name (address can be skipped):
         from: Dev Eco
         # Optional whether this connection use TLS (default is true if server_port is 465)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,110 @@ on:
     branches: [main]
 
 jobs:
+  conditional_job_checks:
+    runs-on: ubuntu-latest
+    outputs:
+      python_changed: ${{ steps.check_changed.outputs.python_changed }}
+      dotnet_changed: ${{ steps.check_changed.outputs.dotnet_changed }}
+      golang_changed: ${{ steps.check_changed.outputs.golang_changed }}
+      java_changed: ${{ steps.check_changed.outputs.java_changed }}
+      javascript_changed: ${{ steps.check_changed.outputs.javascript_changed }}
+      rust_changed: ${{ steps.check_changed.outputs.rust_changed }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - shell: bash
+      id: check_changed
+      run: |
+        mydiffs=`git diff --name-only HEAD^ HEAD`
+        echo "::set-output name=python_changed::`echo "$mydiffs" | grep "^python/" | wc -l`"
+        echo "::set-output name=dotnet_changed::`echo "$mydiffs" | grep "^dotnet/" | wc -l`"
+        echo "::set-output name=golang_changed::`echo "$mydiffs" | grep "^golang/" | wc -l`"
+        echo "::set-output name=java_changed::`echo "$mydiffs" | grep "^java/" | wc -l`"
+        echo "::set-output name=javascript_changed::`echo "$mydiffs" | grep "^javascript/" | wc -l`"
+        echo "::set-output name=rust_changed::`echo "$mydiffs" | grep "^rust/" | wc -l`"
+
+  python:
+    runs-on: ubuntu-latest
+    needs: [conditional_job_checks]
+    if: ${{ needs.conditional_job_checks.outputs.python_changed != 0 }}
+    env:
+      # TODO: remove token stored as secret in favor of using a
+      # momento-local instance that can be spun up for testing
+      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Python SDK sample
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Run samples
+        id: validation
+        continue-on-error: true
+        run: |
+          pushd python
+            python -m pip install --user pipenv
+            pipenv install
+            pipenv run python example.py
+            pipenv run python example_async.py
+          popd
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/error-email-action
+        with:
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1
+
+  csharp:
+    runs-on: ubuntu-latest
+    needs: [conditional_job_checks]
+    if: ${{ needs.conditional_job_checks.outputs.dotnet_changed != 0 }}
+    env:
+      # TODO: remove token stored as secret in favor of using a
+      # momento-local instance that can be spun up for testing
+      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Run samples
+        id: validation
+        continue-on-error: true
+        run: |
+          pushd dotnet/MomentoExamples
+            dotnet build
+            dotnet run --project MomentoApplication
+          popd
+        shell: bash
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/error-email-action
+        with:
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1
+
   javascript:
     runs-on: ubuntu-latest
+    needs: [conditional_job_checks]
+    if: ${{ needs.conditional_job_checks.outputs.javascript_changed != 0 }}
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      # TODO: remove token stored as secret in favor of using a
+      # momento-local instance that can be spun up for testing
+      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - name: Setup repo
@@ -22,14 +122,26 @@ jobs:
           node-version: 16
 
       - name: Install Deps and Build
+        id: validation
         run: |
           pushd javascript
             npm ci
             npm run build
           popd
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/error-email-action
+        with:
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1
 
   java:
     runs-on: ubuntu-latest
+    needs: [conditional_job_checks]
+    if: ${{ needs.conditional_job_checks.outputs.java_changed != 0 }}
 
     steps:
       - name: Setup repo
@@ -48,46 +160,42 @@ jobs:
           popd
 
       - name: Build with Gradle
+        id: validation
         run: |
           pushd java
             ./gradlew clean build
           popd
-
-  csharp:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Setup repo
-        uses: actions/checkout@v2
-
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/error-email-action
         with:
-          dotnet-version: "6.0.x"
-
-      - name: Configure Artifactory
-        run: |
-          set -e
-          set -x
-          dotnet nuget add source https://momento.jfrog.io/artifactory/api/nuget/nuget-public --name Artifactory
-        shell: bash
-
-      - name: Build
-        run: |
-          pushd dotnet/MomentoExamples
-            dotnet build
-          popd
-        shell: bash
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1
 
   rust:
     runs-on: ubuntu-latest
+    needs: [conditional_job_checks]
+    if: ${{ needs.conditional_job_checks.outputs.rust_changed != 0 }}
 
     steps:
       - uses: actions/checkout@v2
       - name: rustfmt -> rigorous lint via Clippy -> build
+        id: validation
         run: |
           pushd rust
             cargo fmt -- --check
             cargo clippy --all-targets --all-features -- -D warnings
             cargo build --verbose
           popd
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/error-email-action
+        with:
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
Adds dependabot configuration to monitor our SDK versions (#99) . When newer versions than the ones used in the examples are detected, a PR is automatically opened and the samples are validated. If the new SDK packages cause an error in the samples, an email is sent to eng-deveco. 